### PR TITLE
New ChangeLog section

### DIFF
--- a/5_changelog.html
+++ b/5_changelog.html
@@ -1,0 +1,25 @@
+---
+layout: default
+title: ChangeLog
+permalink: /ChangeLog/
+---
+
+<div class="home">
+
+
+  <ul class="post-list">
+    {% for post in site.posts %}
+      <li>
+        <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
+
+        <h2>
+          <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+        </h2>
+        {{ post.excerpt }}
+      </li>
+    {% endfor %}
+  </ul>
+
+  <p class="rss-subscribe">subscribe <a href="{{ "/feed.xml" | prepend: site.baseurl }}">via RSS</a></p>
+
+</div>

--- a/_posts/2015-02-11-initial-draft-released.md
+++ b/_posts/2015-02-11-initial-draft-released.md
@@ -1,0 +1,33 @@
+---
+layout: post
+title: Initial Draft Released
+tags: [Repository]
+author: Joshua McDougall
+---
+
+After months of initial effort, the draft document that outlines the CryptoCurrency Security Standard has been converted into this public repository and released to the world for review and collaboration. 
+
+This draft was created as a result a number of contributions by BitGo and C4, as well as the review of other industry leaders.  
+
+### Original Authors 
+
+[C4](https://cryptoconsortium.org) 
+
+* Joshua McDougall 
+* Michael Perklin
+
+[BitGo](https://bitgo.com)
+
+* Mike Belshe
+* Ben Davenport 
+* Will O'Brien 
+
+### Additional Contributors
+* Andreas M. Antonopoulos
+* Nicholas Johnston, [Sheridan](https://www.sheridancollege.ca)
+* Eric Lombrozo, [Ciphrex](https://ciphrex.com)
+* Sergio Lerner, [Coinspect](https://coinspect.com/)
+* John Velissarios, [Amrory Enterprise](https://bitcoinarmory.com)
+
+
+

--- a/_posts/2015-03-12-added-PBKDF2-as-described-in-BIP39.md
+++ b/_posts/2015-03-12-added-PBKDF2-as-described-in-BIP39.md
@@ -1,0 +1,19 @@
+---
+layout: post
+title: Added PBKDF2 as Described in BIP39
+tags: [Key Storage, BIP39]
+author: Ryan X. Charles
+---
+
+[1.03 Key Storage](/CCSS/Details/#1.03) aspect was expanded to allow for Password-Based Key Derivation as an alternative to storing the key in an encrypted state. With Password-Based Key Derivation, the seed can be stored unencrypted as the password used to derive the key from the seed would accomplish the same as a passworded encryption layer on top of the seed. 
+
+### References
+* [http://en.wikipedia.org/wiki/PBKDF2](http://en.wikipedia.org/wiki/PBKDF2)
+* [https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)
+
+### Contributor(s)
+* Ryan X. Charles, [BitGo](https://bitgo.com)
+
+
+
+

--- a/_posts/2015-04-06-changelog-system-added.md
+++ b/_posts/2015-04-06-changelog-system-added.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: ChangeLog System Added
+tags: [Repository]
+author: Joshua McDougall
+---
+
+Commit history is a great tool but it doesn't always allow us to tell the entire story, or easily access it. Now, when submitting changes to the CCSS, we suggest that you include a post like this one describing the changes, outlining the reasoning for the change, and the impact it may have on established environments. 
+
+Although not a requirement, we welcome you to include details on the contirbutors and their affiliations as well.
+
+This changelog is written to take advantage of the static blogging capabilities already built into Jekyll. Posts like this one are written in markdown and saved to the _posts folder of the repository. All changelog entries should be named in the format YYYY-MM-DD-title.md in order to be picked up by the engine. 
+
+We have included a template document (YYYY-MM-DD-template.md) into the repository which can be copied as the basis for all changelog posts. 
+
+Modest sized images for explaining concepts or showing sponsorship/affiliations can  be included in the images directory. This is prefered over the use of external links. 
+
+### Change Contributor(s)
+Joshua McDougall, [C4](https://cryptoconsortium.org) 
+
+
+

--- a/_posts/YYYY-MM-DD-template.md
+++ b/_posts/YYYY-MM-DD-template.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: Tempalte
+tags: [a,list,of,tags]
+author: Post Author
+---
+
+Commit history is a great tool but it doesn't always allow us to tell the entire story. Now, when submitting changes to the CCSS, we suggest that you include a post like this one describing the changes and outlining the reasoning for the change and the impact it may have on established environments. 
+
+These new commits include details on the contirbutors as well. 
+
+This changelog is written to take advantage of the static blogging capabilities already built into Jekyll. Posts like this one are written in markdown and saved to the _posts folder of the repository. All changelog entries should be named in the format YYYY-MM-DD-title.md in order to be picked up by the engine. 
+
+We have included a template document (YYYY-MM-DD-template.md) into the repository which can be copied as the basis for all changelog posts. 
+
+Modest sized images for explaining concepts or showing sponsorship/affiliations can  be included in the images directory. This is prefered over the use of external links. 
+
+### Change Contributor(s)
+[Names], [C4](https://yourlink.com) 
+[Of], [C4](https://yourlink.com) 
+[All], [C4](https://yourlink.com) 
+[Involved], [C4](https://yourlink.com) 
+
+

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,30 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ site.title | xml_escape }}</title>
+    <description>{{ site.description | xml_escape }}</description>
+    <link>{{ site.url }}{{ site.baseurl }}/</link>
+    <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+    <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
+    <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+    <generator>Jekyll v{{ jekyll.version }}</generator>
+    {% for post in site.posts limit:10 %}
+      <item>
+        <title>{{ post.title | xml_escape }}</title>
+        <description>{{ post.content | xml_escape }}</description>
+        <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
+        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
+        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+        {% for tag in post.tags %}
+        <category>{{ tag | xml_escape }}</category>
+        {% endfor %}
+        {% for cat in post.categories %}
+        <category>{{ cat | xml_escape }}</category>
+        {% endfor %}
+      </item>
+    {% endfor %}
+  </channel>
+</rss>


### PR DESCRIPTION
Although GitHub is great for discussion, I wanted to make sure that changes to the standard, along with the reasoning and impact, are prominently displayed within the CCSS site. To solve that problem, I have taken the built-in static blogging features of Jekyll and exposed that as a changelog.  

I have also gone ahead and created some back-dated content. 